### PR TITLE
Fix/update fsrs.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "deepcopy": "^2.1.0",
                 "esbuild": "~0.17.18",
                 "eslint": "^8.40.0",
-                "fsrs.js": "^1.0.0",
+                "fsrs.js": "^1.1.0",
                 "jest": "^29.5.0",
                 "jest-environment-jsdom": "^29.5.0",
                 "jest-expect-message": "^1.1.3",
@@ -5053,9 +5053,9 @@
             }
         },
         "node_modules/fsrs.js": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fsrs.js/-/fsrs.js-1.0.0.tgz",
-            "integrity": "sha512-yPyogcMCXRgISBzBUOjFnSE4JH4COpe1ISbj5Jzf7y7sLxNM8JaoPYPUvFIS6dA9JySOHg46FqCjXvBm9KrZdg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fsrs.js/-/fsrs.js-1.1.0.tgz",
+            "integrity": "sha512-DEihBx081nENpNjrSvCopPVi9Ilh+u+ELYOKQmshfSz+DgC/B0hxFFMQnqy2ibWAm9zjyR/bWvaz86xEA4MIcA==",
             "dev": true,
             "dependencies": {
                 "deepcopy": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "deepcopy": "^2.1.0",
         "esbuild": "~0.17.18",
         "eslint": "^8.40.0",
-        "fsrs.js": "^1.0.0",
+        "fsrs.js": "^1.1.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "jest-expect-message": "^1.1.3",


### PR DESCRIPTION
fsrs.js 那边修了复习回忆成功的稳定性计算公式，建议这里也升级依赖。